### PR TITLE
Add building rotate

### DIFF
--- a/src/editor/Board.ts
+++ b/src/editor/Board.ts
@@ -107,8 +107,18 @@ export class Board {
             Building.createSpriteModel({
                 snap: this.snap,
                 id: building,
+                rotated: false,
             }).attr({
                 id: building,
+            }).toDefs();
+
+            // rotated version
+            Building.createSpriteModel({
+                snap: this.snap,
+                id: building,
+                rotated: true,
+            }).attr({
+                id: `${building}_rotated`,
             }).toDefs();
         });
     }

--- a/src/editor/Building.ts
+++ b/src/editor/Building.ts
@@ -7,12 +7,14 @@ interface BuildingProps {
     snap: Snap.Paper;
     x: number;
     y: number;
+    rotated: boolean;
     placementMode: boolean;
 }
 
 interface SpriteModelProps {
     id: string;
     snap: Snap.Paper;
+    rotated: boolean;
 }
 
 export class Building {
@@ -22,6 +24,7 @@ export class Building {
     set: Snap.Element;
     width: number;
     height: number;
+    isRotated: boolean;
     x: number;
     y: number;
 
@@ -30,17 +33,20 @@ export class Building {
         dataId,
         x,
         y,
+        rotated,
         placementMode,
     }: BuildingProps) {
         this.bid = uuidv4();
         this.snap = snap;
+        this.isRotated = rotated;
         this.dataId = dataId;
         const info = BUILDINGS[dataId];
-        this.width = info.width;
-        this.height = info.height;
+        this.width = this.isRotated ? info.height : info.width;
+        this.height = this.isRotated ? info.width : info.height;
         this.x = x;
         this.y = y;
-        this.set = this.snap.use(dataId) as Snap.Element;
+        const rotateDataIdMap = `${this.dataId}${rotated ? "_rotated" : ""}`;
+        this.set = this.snap.use(rotateDataIdMap) as Snap.Element;
         this.set.attr({id: this.bid});
 
         if (placementMode) {
@@ -68,6 +74,7 @@ export class Building {
             dataId,
             x,
             y,
+            isRotated,
         } = building;
 
         return new Building({
@@ -75,16 +82,18 @@ export class Building {
             dataId: dataId,
             x: x,
             y: y,
+            rotated: isRotated,
             placementMode: false,
         });
     }
     
-    static create = (snap: Snap.Paper, selection: string, x: number, y: number) => {
+    static create = (snap: Snap.Paper, selection: string, x: number, y: number, rotated: boolean) => {
         return new Building({
             snap: snap,
             dataId: selection,
             x: x,
             y: y,
+            rotated: rotated,
             placementMode: true,
         });
     }
@@ -92,17 +101,20 @@ export class Building {
     static createSpriteModel = ({
         snap,
         id,
+        rotated,
     }: SpriteModelProps) => {
 
-        const {width, height, colour } = BUILDINGS[id];
-        const squareSize = Math.min(width, height) / 2;
-        const centerX = width / 2 - squareSize / 2;
-        const centerY = height / 2 - squareSize / 2;
+        const { width, height, colour } = BUILDINGS[id];
+        const actualWidth = rotated ? height : width;
+        const actualHeight = rotated ? width : height;
+        const squareSize = Math.min(actualWidth, actualHeight) / 2;
+        const centerX = actualWidth / 2 - squareSize / 2;
+        const centerY = actualHeight / 2 - squareSize / 2;
         const background = snap.rect(
             0.5,
             0.5,
-            width * GRID.SIZE - 1, 
-            height * GRID.SIZE - 1)
+            actualWidth * GRID.SIZE - 1, 
+            actualHeight * GRID.SIZE - 1)
             .attr({
                 "fill-opacity": 1,
                 stroke: "#000",

--- a/src/editor/Cursor.ts
+++ b/src/editor/Cursor.ts
@@ -26,7 +26,7 @@ export class Cursor {
         this.snap = this.board.snap;
         this.x = 0;
         this.y = 0;
-        this.selection = Building.create(this.snap, selection, this.x, this.y);
+        this.selection = Building.create(this.snap, selection, this.x, this.y, false);
         this.selectMode = SelectMode.ADD;
         this.isSelected = false;
         this.updateSelectMode(this.selectMode);
@@ -46,6 +46,12 @@ export class Cursor {
         if (this.selection.dataId === "cursor") {
             return;
         }
+
+        if (event.ctrlKey) {
+            this.setSelection(this.selection.dataId, !this.selection.isRotated);
+            return;
+        }
+
         this.board.addBuilding(Building.clone(this.selection));
     }
 
@@ -78,7 +84,7 @@ export class Cursor {
                 return;
             }
 
-            this.setSelection(building.dataId);
+            this.setSelection(building.dataId, building.isRotated);
             this.isSelected = true;
             this.board.deleteBuilding(id);
             return;
@@ -126,12 +132,12 @@ export class Cursor {
         });
     }
 
-    setSelection = (selection: string) => {
+    setSelection = (selection: string, rotated: boolean = false) => {
         if (this.selectMode === SelectMode.ERASE) {
             return;
         }
         this.selection.clear();
-        this.selection = Building.create(this.snap, selection, this.x, this.y);
+        this.selection = Building.create(this.snap, selection, this.x, this.y, rotated);
     }
 
     updateSelectMode = (selectMode: SelectMode) => {


### PR DESCRIPTION
Added the ability to rotate by holding down ctrl and doing a mousedown event. Currently, this is done through created more use elements that store the rotated version and just calling to those when we have a rotated version. May have to refactor this as the building class is getting big.